### PR TITLE
Ensure auto healing deactivates after each test

### DIFF
--- a/apps/app.py
+++ b/apps/app.py
@@ -259,6 +259,8 @@ class QAQualityRadar:
             await self.operational_manager.save_test_error(test_id, str(e))
 
         finally:
+            await self.auto_healing.disable()
+            self.auto_healing.reset_healing_actions()
             await self.mcp_client.disconnect()
 
     async def _execute_scenario(self, scenario: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- Disable auto-healing and reset healing action logs after each test run
- Keep cleanup in `_execute_test` to run regardless of success or failure

## Testing
- `npm test` *(fails: Cannot find module 'test_server.js')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'apps')*

------
https://chatgpt.com/codex/tasks/task_b_68b141d668988330898809563b078e83